### PR TITLE
Support user_id on note push

### DIFF
--- a/copper_sdk/notes.py
+++ b/copper_sdk/notes.py
@@ -13,15 +13,15 @@ class Notes:
     def __init__(self, copper):
         self.copper = copper
 
-    def push(self, target: NoteTarget, target_id, content):
-        """Send notes to a task"""
+    def push(self, target: NoteTarget, target_id, content, user_id = 0):
+        """Send notes into an NoteTarget entity"""
 
         parent = {
             "type": target.to_str(),
             "id": target_id
         }
 
-        # Fixed value from Copper for tasks.
+        # Fixed value from Copper for notes.
         req_type = {
             "category": "user",
             "id": 0
@@ -33,18 +33,22 @@ class Notes:
             "details": content
         }
 
+        if isinstance(user_id, int):
+            if user_id > 0:
+                body["user_id"] = user_id
+
         return self.copper.activities().create(body)
 
-    def get(self, target: NoteTarget, target_id):
-        """Request notes from a task"""
+    def get(self, target: NoteTarget, target_id, user_id = 0):
+        """Request notes from an NoteTarget entity"""
 
-        task_parent = {
+        parent = {
             "type": target.to_str(),
             "id": target_id
         }
 
         body = {
-            "parent": task_parent
+            "parent": parent
         }
 
         return self.copper.activities().list(body)

--- a/runner/README.md
+++ b/runner/README.md
@@ -14,6 +14,7 @@ EMAIL=[Your CopperCRM email]
 TASK_ID=[A Task Id to perform examples]
 LEAD_ID=[A Lead Id to perform examples]
 OPPORTUNITY_ID=[An Opportunity Id to perform examples]
+USER_ID=[The User Id]
 ```
 
 When executing examples, there could be a wait of 7 secs per examples, to let

--- a/runner/notes/lead.py
+++ b/runner/notes/lead.py
@@ -3,7 +3,7 @@ import names_generator
 import json
 import shared_procs
 
-def create_lead_note(copper_client, lead_id):
+def create_lead_note(copper_client, lead_id, user_id):
     """Create a note for a Lead
     
     Attributes:
@@ -21,7 +21,7 @@ def create_lead_note(copper_client, lead_id):
     target = NoteTarget.Lead
     name = names_generator.generate_name(style="capital")
     content = f"{name} greets you from Python"
-    return notes.push(target, lead_id, content)
+    return notes.push(target, lead_id, content, user_id)
 
 def get_lead_notes(copper_client, lead_id):
     """Get notes of a Lead.
@@ -44,9 +44,10 @@ def get_lead_notes(copper_client, lead_id):
 def run(copper_client, config):
     print("Running Lead Notes examples")
     lead_id = config["LEAD_ID"]
+    user_id = int(config["USER_ID"])
 
     print("Creating note for Lead Id", lead_id)
-    new_lead_note = create_lead_note(copper_client, lead_id)
+    new_lead_note = create_lead_note(copper_client, lead_id, user_id)
     print("Note:", json.dumps(new_lead_note))
 
     shared_procs.wait()

--- a/runner/notes/opportunity.py
+++ b/runner/notes/opportunity.py
@@ -3,7 +3,7 @@ import names_generator
 import json
 import shared_procs
 
-def create_opportunity_note(copper_client, opportunity_id):
+def create_opportunity_note(copper_client, opportunity_id, user_id):
     """Create a note for a Opportunity
     
     Attributes:
@@ -21,7 +21,7 @@ def create_opportunity_note(copper_client, opportunity_id):
     target = NoteTarget.Opportunity
     name = names_generator.generate_name(style="capital")
     content = f"{name} greets you from Python"
-    return notes.push(target, opportunity_id, content)
+    return notes.push(target, opportunity_id, content, user_id)
 
 def get_opportunity_notes(copper_client, opportunity_id):
     """Get notes of a Opportunity.
@@ -45,9 +45,10 @@ def get_opportunity_notes(copper_client, opportunity_id):
 def run(copper_client, config):
     print("Running Opportunity Notes examples")
     opportunity_id = config["OPPORTUNITY_ID"]
+    user_id = int(config["USER_ID"])
 
     print("Creating note for Opportunity Id", opportunity_id)
-    new_opportunity_note = create_opportunity_note(copper_client, opportunity_id)
+    new_opportunity_note = create_opportunity_note(copper_client, opportunity_id, user_id)
     print("Note:", json.dumps(new_opportunity_note))
 
     shared_procs.wait()

--- a/runner/notes/task.py
+++ b/runner/notes/task.py
@@ -3,7 +3,7 @@ import names_generator
 import json
 import shared_procs
 
-def create_task_note(copper_client, task_id):
+def create_task_note(copper_client, task_id, user_id):
     """Create a note for a Task
     
     Attributes:
@@ -21,7 +21,7 @@ def create_task_note(copper_client, task_id):
     target = NoteTarget.Task
     name = names_generator.generate_name(style="capital")
     content = f"{name} greets you from Python"
-    return notes.push(target, task_id, content)
+    return notes.push(target, task_id, content, user_id)
 
 def get_task_notes(copper_client, task_id):
     """Get notes of a Task.
@@ -45,9 +45,10 @@ def get_task_notes(copper_client, task_id):
 def run(copper_client, config):
     print("Running Task Notes examples")
     task_id = config["TASK_ID"]
+    user_id = int(config["USER_ID"])
 
     print("Creating note for Task Id", task_id)
-    new_task_note = create_task_note(copper_client, task_id)
+    new_task_note = create_task_note(copper_client, task_id, user_id)
     print("Note:", json.dumps(new_task_note))
 
     shared_procs.wait()


### PR DESCRIPTION
For note push, when `user_id` is `int` instance and is > 0, then it is added to the note push.

If `user_id` does not exist, CopperCRM will return a msg like following:

```json
{
  "success": false,
  "status": 422,
  "message": "Invalid request: No user exists with ID '915901'."
}
```